### PR TITLE
Move to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.1",
   "description": "Version read/write plugin for release-it",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "bron test.js",
     "release": "release-it"
@@ -40,12 +41,12 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "bron": "^1.1.1",
-    "release-it": "^14.10.0",
+    "bron": "^2.0.3",
+    "release-it": "^15.0.0-esm.3",
     "sinon": "^11.1.1"
   },
   "peerDependencies": {
-    "release-it": "^14.0.0"
+    "release-it": "^15.0.0-esm.3"
   },
   "engines": {
     "node": ">=10"

--- a/test.js
+++ b/test.js
@@ -1,10 +1,11 @@
-const fs = require('fs');
-const { EOL } = require('os');
-const assert = require('assert').strict;
-const test = require('bron');
-const mock = require('mock-fs');
-const { factory, runTasks } = require('release-it/test/util');
-const Plugin = require('.');
+import test from 'bron';
+import { readFileSync } from 'fs';
+import { EOL } from 'os';
+
+import assert from 'assert';
+import mock from 'mock-fs';
+import Bumper from './index.js';
+import { factory, runTasks } from 'release-it/test/util';
 
 mock({
   './bower.json': JSON.stringify({ version: '1.0.0' }) + EOL,
@@ -22,129 +23,167 @@ mock({
 
 const namespace = 'bumper';
 
-const readFile = file => fs.readFileSync(file).toString();
+const readFile = file => readFileSync(file).toString();
 
 test('should not throw', async () => {
   const options = { [namespace]: {} };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await assert.doesNotReject(runTasks(plugin));
 });
 
 test('should return latest version from JSON file', async () => {
   const options = { [namespace]: { in: './bower.json' } };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   const version = await plugin.getLatestVersion();
   assert.equal(version, '1.0.0');
 });
 
 test('should return latest version from plain text file', async () => {
-  const options = { [namespace]: { in: { file: './foo.txt', type: 'text/plain' } } };
-  const plugin = factory(Plugin, { namespace, options });
+  const options = {
+    [namespace]: { in: { file: './foo.txt', type: 'text/plain' } }
+  };
+  const plugin = factory(Bumper, { namespace, options });
   const version = await plugin.getLatestVersion();
   assert.equal(version, '1.0.0');
 });
 
 test('should return latest version from plain text file (.txt)', async () => {
   const options = { [namespace]: { in: { file: './foo.txt' } } };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   const version = await plugin.getLatestVersion();
   assert.equal(version, '1.0.0');
 });
 
 test('should return latest version from YAML file', async () => {
   const options = { [namespace]: { in: './foo.yaml' } };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   const version = await plugin.getLatestVersion();
   assert.equal(version, '1.0.0');
 });
 
 test('should write indented JSON file', async () => {
   const options = { [namespace]: { out: './manifest.json' } };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await plugin.bump('1.2.3');
   assert.equal(readFile('./manifest.json'), `{${EOL}  "version": "1.2.3"${EOL}}${EOL}`);
 });
 
 test('should write new, indented JSON file', async () => {
   const options = { [namespace]: { out: ['./null.json'] } };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await plugin.bump('0.0.0');
   assert.equal(readFile('./null.json'), `{${EOL}  "version": "0.0.0"${EOL}}${EOL}`);
 });
 
 test('should write version at path', async () => {
-  const options = { [namespace]: { out: { file: './deep.json', path: 'deep.sub.version' } } };
-  const plugin = factory(Plugin, { namespace, options });
+  const options = {
+    [namespace]: { out: { file: './deep.json', path: 'deep.sub.version' } }
+  };
+  const plugin = factory(Bumper, { namespace, options });
   await plugin.bump('1.2.3');
   assert.equal(readFile('./deep.json'), JSON.stringify({ deep: { sub: { version: '1.2.3' } } }, null, '  ') + EOL);
 });
 
 test('should write version at multiple paths', async () => {
   const options = {
-    [namespace]: { out: { file: './multi.json', path: ['version', 'deep.version', 'deep.sub.version'] } }
+    [namespace]: {
+      out: {
+        file: './multi.json',
+        path: ['version', 'deep.version', 'deep.sub.version']
+      }
+    }
   };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await plugin.bump('1.2.3');
   assert.equal(
     readFile('./multi.json'),
-    JSON.stringify({ version: '1.2.3', deep: { version: '1.2.3', sub: { version: '1.2.3' } } }, null, '  ') + EOL
+    JSON.stringify(
+      {
+        version: '1.2.3',
+        deep: { version: '1.2.3', sub: { version: '1.2.3' } }
+      },
+      null,
+      '  '
+    ) + EOL
   );
 });
 
 test('should write plain version text file', async () => {
-  const options = { [namespace]: { out: [{ file: './VERSION-OUT', type: 'text/plain' }] } };
-  const plugin = factory(Plugin, { namespace, options });
+  const options = {
+    [namespace]: { out: [{ file: './VERSION-OUT', type: 'text/plain' }] }
+  };
+  const plugin = factory(Bumper, { namespace, options });
   await plugin.bump('3.2.1');
   assert.equal(readFile('./VERSION-OUT'), `3.2.1${EOL}`);
 });
 
 test('should write plain version text file (default text type)', async () => {
   const options = { [namespace]: { out: [{ file: './VERSION-OUT' }] } };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await plugin.bump('3.2.1');
   assert.equal(readFile('./VERSION-OUT'), `3.2.1${EOL}`);
 });
 
 test('should write toml file', async () => {
-  const options = { [namespace]: { out: { file: './foo.toml', type: 'application/toml', path: 'tool.test.version' } } };
-  const plugin = factory(Plugin, { namespace, options });
+  const options = {
+    [namespace]: {
+      out: {
+        file: './foo.toml',
+        type: 'application/toml',
+        path: 'tool.test.version'
+      }
+    }
+  };
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./foo.toml'), `[tool.test]${EOL}version = "1.0.1"${EOL}`);
 });
 
 test('should write toml file (.toml)', async () => {
-  const options = { [namespace]: { out: { file: './foo.toml', path: 'tool.test.version' } } };
-  const plugin = factory(Plugin, { namespace, options });
+  const options = {
+    [namespace]: { out: { file: './foo.toml', path: 'tool.test.version' } }
+  };
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./foo.toml'), `[tool.test]${EOL}version = "1.0.1"${EOL}`);
 });
 
 test('should write ini file', async () => {
-  const options = { [namespace]: { out: { file: './foo.ini', path: 'path.version' } } };
-  const plugin = factory(Plugin, { namespace, options });
+  const options = {
+    [namespace]: { out: { file: './foo.ini', path: 'path.version' } }
+  };
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./foo.ini'), `path.version=1.0.1${EOL}path.name=fake${EOL}`);
 });
 
 test('should write plain text file', async () => {
-  const options = { [namespace]: { in: './bower.json', out: { file: './foo.php', type: 'text/php' } } };
-  const plugin = factory(Plugin, { namespace, options });
+  const options = {
+    [namespace]: {
+      in: './bower.json',
+      out: { file: './foo.php', type: 'text/php' }
+    }
+  };
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./foo.php'), `/* comments${EOL}version: v1.0.1 */ <? echo <p>hello world</p>; ?>${EOL}`);
 });
 
 test('should write YAML file', async () => {
   const options = { [namespace]: { out: { file: './foo.yaml' } } };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./foo.yaml'), `version: 1.0.1${EOL}`);
 });
 
 test('should read/write plain text file', async () => {
   const options = {
-    [namespace]: { in: { file: './foo.txt', type: 'text/plain' }, out: { file: './foo.txt', type: 'text/plain' } }
+    [namespace]: {
+      in: { file: './foo.txt', type: 'text/plain' },
+      out: { file: './foo.txt', type: 'text/plain' }
+    }
   };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./foo.txt'), `1.0.1${EOL}`);
 });
@@ -153,7 +192,7 @@ test('should read/write plain text file (.txt)', async () => {
   const options = {
     [namespace]: { in: { file: './foo.txt' }, out: { file: './foo.txt' } }
   };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./foo.txt'), `1.0.1${EOL}`);
 });
@@ -162,7 +201,7 @@ test('should read one and write multiple files', async () => {
   const options = {
     [namespace]: { in: { file: './foo.txt' }, out: './foo*.txt' }
   };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./foo.txt'), `1.0.1${EOL}`);
   assert.equal(readFile('./foo2.txt'), `1.0.1${EOL}`);
@@ -170,9 +209,12 @@ test('should read one and write multiple files', async () => {
 
 test('should read one and write multiple files and respect prefix', async () => {
   const options = {
-    [namespace]: { in: { file: 'VERSION', type: 'text/plain' }, out: ['README.md', 'VERSION'] }
+    [namespace]: {
+      in: { file: 'VERSION', type: 'text/plain' },
+      out: ['README.md', 'VERSION']
+    }
   };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./README.md'), `Release v1.0.1${EOL}`);
   assert.equal(readFile('./VERSION'), `v1.0.1${EOL}`);
@@ -180,9 +222,11 @@ test('should read one and write multiple files and respect prefix', async () => 
 
 test('should write various file types', async () => {
   const options = {
-    [namespace]: { out: [{ file: './foo*.txt' }, { file: './(bower|manifest).json' }] }
+    [namespace]: {
+      out: [{ file: './foo*.txt' }, { file: './(bower|manifest).json' }]
+    }
   };
-  const plugin = factory(Plugin, { namespace, options });
+  const plugin = factory(Bumper, { namespace, options });
   await runTasks(plugin);
   assert.equal(readFile('./foo.txt'), `1.0.1${EOL}`);
   assert.equal(readFile('./foo2.txt'), `1.0.1${EOL}`);
@@ -192,7 +236,11 @@ test('should write various file types', async () => {
 
 test('should not write in dry run', async () => {
   const options = { [namespace]: { in: './dryrun.json' } };
-  const plugin = factory(Plugin, { namespace, options, global: { isDryRun: true } });
+  const plugin = factory(Bumper, {
+    namespace,
+    options,
+    global: { isDryRun: true }
+  });
   await plugin.bump('1.0.1');
   assert.equal(readFile('./dryrun.json'), `{"version":"1.0.0"}${EOL}`);
 });


### PR DESCRIPTION
@webpro I don't know why it's failing the tests.

```
⟩ npm test

> @release-it/bumper@3.0.1 test
> bron test.js

✔ should not write in dry run
✔ should not throw
✔ should write new, indented JSON file
✔ should write version at path
✔ should write version at multiple paths
✔ should write plain version text file
✔ should write plain version text file (default text type)
fish: Job 1, 'npm test' terminated by signal SIGABRT (Abort)
```