### PR TITLE
Fix test path not exported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         node:
           - 14
           - 16
+          - 18
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} (Node v${{ matrix.node }})

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   "devDependencies": {
     "bron": "^2.0.3",
     "mock-fs": "^5.1.2",
-    "release-it": "^15.0.0-esm.4",
+    "release-it": "^15.2.0",
     "sinon": "^13.0.2"
   },
   "peerDependencies": {
-    "release-it": "^15.0.0-esm.4"
+    "release-it": "^15.2.0"
   },
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "4.0.0",
   "description": "Version read/write plugin for release-it",
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "bron test.js",
     "release": "release-it"

--- a/test.js
+++ b/test.js
@@ -4,8 +4,8 @@ import { EOL } from 'os';
 
 import assert from 'assert';
 import mock from 'mock-fs';
-import Bumper from './index.js';
 import { factory, runTasks } from 'release-it/test/util/index.js';
+import Bumper from './index.js';
 
 mock({
   './bower.json': JSON.stringify({ version: '1.0.0' }) + EOL,

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ import { EOL } from 'os';
 import assert from 'assert';
 import mock from 'mock-fs';
 import Bumper from './index.js';
-import { factory, runTasks } from 'release-it/test/util';
+import { factory, runTasks } from 'release-it/test/util/index.js';
 
 mock({
   './bower.json': JSON.stringify({ version: '1.0.0' }) + EOL,


### PR DESCRIPTION
Experiencing error in `npm test`.
Fix it here.

> ✖ test.js
> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './test/util' is not defined by "exports" in C:\bumper\node_modules\release-it\package.json imported from C:\bumper\test.js

Because of https://github.com/release-it/release-it/pull/921 (fixed in [15.1.3](https://github.com/release-it/release-it/releases/tag/15.1.3)).

Updating `release-it` dep to [^15.2.0](https://github.com/release-it/release-it/releases/tag/15.2.0) for `exports` to be "complete".

\+ correct exports (like https://github.com/release-it/conventional-changelog/commit/b19b6e826e82dce02b0f8c64e47c72a192028bda, and https://github.com/release-it/release-it/commit/acc66f7c628d5797594714bb19f8d8e4699d014d)
\+ add Node 18 to test matrix