### PR TITLE
Add a feature for overwriting the whole output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,26 @@ To replace all occurences of the current version with the new version in any tex
 }
 ```
 
+:warning: the operation is a search-and-replace; if the current version is not found in the file, the new version cannot be written out.
+
+To instead always consume the entire file, that is, the whole and only content of the file is the version number, set `consumeWholeFile: true` for the `out` option:
+
+```json
+"plugins": {
+  "@release-it/bumper": {
+    "out": {
+      "file": "VERSION",
+      "type": "text/plain",
+      "consumeWholeFile": true
+    }
+  }
+}
+```
+
+The version number is then written to the output file, overwriting it completely instead of a search-and-replace.
+
+:bulb: Setting `consumeWholeFile: true` precludes the use of prefixes, such as `v1.0.1` in the output file.
+
 The `out` option can also be an array of files:
 
 ```json

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ const parseFileOption = option => {
   const file = isString(option) ? option : option.file;
   const mimeType = typeof option !== 'string' ? option.type : null;
   const path = (typeof option !== 'string' && option.path) || 'version';
-  return { file, mimeType, path };
+  const consumeWholeFile = typeof option !== 'string' ? option.consumeWholeFile : false;
+  return { file, mimeType, path, consumeWholeFile };
 };
 
 const getFileType = (file, mimeType) => {
@@ -63,7 +64,7 @@ class Bumper extends Plugin {
   async getLatestVersion() {
     const { in: option } = this.options;
     if (!option) return;
-    const { file, mimeType, path } = parseFileOption(option);
+    const { file, mimeType, path, consumeWholeFile } = parseFileOption(option);
     if (file) {
       const type = getFileType(file, mimeType);
       let data;
@@ -109,7 +110,7 @@ class Bumper extends Plugin {
 
     return Promise.all(
       options.map(async out => {
-        const { file, mimeType, path } = parseFileOption(out);
+        const { file, mimeType, path, consumeWholeFile } = parseFileOption(out);
         this.log.exec(`Writing version to ${file}`, isDryRun);
         if (isDryRun) return noop;
 
@@ -141,7 +142,7 @@ class Bumper extends Plugin {
             return writeFileSync(file, ini.encode(parsed));
           default:
             const versionMatch = new RegExp(latestVersion || '', 'g');
-            const write = parsed ? parsed.replace(versionMatch, version) : version + EOL;
+            const write = (parsed && !consumeWholeFile) ? parsed.replace(versionMatch, version) : version + EOL;
             return writeFileSync(file, write);
         }
       })


### PR DESCRIPTION
This PR adds an `out` option, `consumeWholeFile` (boolean, default: `false`), which can be used with plain output type files to simply always overwrite the whole file with the new version number, rather that doing a search-and-replace operation with the existing contents (the current behaviour).

This can be useful when the output file cannot be guaranteed to be up-to-date (i.e. contain the matching latest version). It also goes some way to matching the behaviour of structured output files such as JSON — e.g. the new version is always written to the `{ "version" }` field in `package.json`, regardless of whether the existing `{ "version": "<value>" }` matches that latest version or not.

One caveat is that version number prefixes are not retained, e.g. if plain output file `VERSION` contains `v1.0.0`, a patch release would replace it with `1.0.1` (no `v` prefix). This replicates the behaviour when the output file does not exist at all — current behaviour there is that bumper writes the new version number to the file, sans prefix.

Fixes #31  