### PR TITLE
feat: Add `versionPrefix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ The `path` option (default: `"version"`) can be used to change a different prope
 
 Multiple paths can be provided using an array.
 
+The `versionPrefix` option (default: `''`) can be used in cases where you'd like to maintain a specific prefix for your version number (for example, in `package.json` where you might want versions like `^1.0.0`). This will prepend the specified prefix to the bumped version:
+
+``` json
+"plugins": {
+  "@release-it/bumper": {
+    "out": {
+      "file": "package.json",
+      "path": "version",
+      "prefix": "^"
+    }
+  }
+}
+```
+
+With the above configuration, if release-it determines the new version to be `1.0.0`, it'll be saved as `^1.0.0` in the targeted file.
+
 ## Command-line
 
 Options for this plugin can be set from the command line. Some examples:

--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ const parseFileOption = option => {
   const mimeType = typeof option !== 'string' ? option.type : null;
   const path = (typeof option !== 'string' && option.path) || 'version';
   const consumeWholeFile = typeof option !== 'string' ? option.consumeWholeFile : false;
-  return { file, mimeType, path, consumeWholeFile };
+  const versionPrefix = typeof option !== 'string' ? option.versionPrefix : null;
+  return { file, mimeType, path, consumeWholeFile, versionPrefix };
 };
 
 const getFileType = (file, mimeType) => {
@@ -109,7 +110,7 @@ class Bumper extends Plugin {
 
     return Promise.all(
       options.map(async out => {
-        const { file, mimeType, path, consumeWholeFile } = parseFileOption(out);
+        const { file, mimeType, path, consumeWholeFile, versionPrefix = '' } = parseFileOption(out);
         this.log.exec(`Writing version to ${file}`, isDryRun);
         if (isDryRun) return noop;
 
@@ -127,7 +128,7 @@ class Bumper extends Plugin {
         const indent = isString(data) ? detectIndent(data).indent || '  ' : null;
 
         if (typeof parsed !== 'string') {
-          castArray(path).forEach(path => set(parsed, path, version));
+          castArray(path).forEach(path => set(parsed, path, versionPrefix + version));
         }
 
         switch (type) {

--- a/test.js
+++ b/test.js
@@ -324,3 +324,19 @@ test('should read from plain text file, not update out-of-date plain version tex
   assert.equal(readFile('./VERSION'), `v1.0.1${EOL}`);
   assert.equal(readFile('./VERSION-OLD2'), `v0.9.0${EOL}`);
 });
+
+test('should update version in JSON file with prefix', async () => {
+  const options = {
+    [namespace]: {
+      out: {
+        file: './bower.json',
+        path: 'version',
+        versionPrefix: '^'
+      }
+    }
+  };
+
+  const plugin = factory(Bumper, { namespace, options });
+  await runTasks(plugin);
+  assert.equal(readFile('./bower.json'), '{\n  "version": "^1.0.1"\n}\n');
+});


### PR DESCRIPTION
Introduces the `versionPrefix` option for the `out` configuration - this option ensures a specific prefix is prepended to the bumped version. It is especially useful for `package.json` files where version numbers like `^1.0.0` or `~1.0.0` are prevalent (but also supports other semver-compatible prefixes like: `>=`, `>`, `<`, `<=`)