### PR TITLE
fix: toml formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,9 +172,16 @@ class Bumper extends Plugin {
           case 'yaml':
             return writeFileSync(file, yaml.dump(parsed, { indent: indent.length }));
           case 'toml':
-            const tomlString = toml.stringify(parsed);
-            // handle empty objects for sections
-            const tomlContent = tomlString.replace(/^([a-zA-Z0-9\.\-]+) \= \{ \}/g, '[$1]');
+            var tomlContent = data;
+
+            castArray(path).forEach(path => {
+              const latestPath = path.split('.').at(-1);
+              const versionMatch = new RegExp(`${latestPath}[\\W\\w]+?(${latestVersion.replaceAll('.', '\\.')})` || '');
+              tomlContent = tomlContent.replace(versionMatch, (match, group1) => {
+                return match.replace(group1, versionPrefix + version);
+              });
+            });
+
             return writeFileSync(file, tomlContent);
           case 'ini':
             return writeFileSync(file, ini.encode(parsed));

--- a/test/toml.test.js
+++ b/test/toml.test.js
@@ -10,7 +10,8 @@ import { readFile } from './globals/file-utils.js';
 
 mock({
   './foo.toml': `[tool.test]${EOL}version = "${CURRENT_VERSION}"${EOL}`,
-  './cargo.toml': `[workspace]${EOL}${EOL}[package]${EOL}name = "hello_world"${EOL}version = "${CURRENT_VERSION}"${EOL}authors = [ "Alice <a@example.com>", "Bob <b@example.com>" ]${EOL}${EOL}[dependencies]${EOL}time = "0.1.12"${EOL}`
+  './cargo.toml': `[workspace]${EOL}${EOL}[package]${EOL}name = "hello_world"${EOL}version = "${CURRENT_VERSION}"${EOL}authors = [ "Alice <a@example.com>", "Bob <b@example.com>" ]${EOL}${EOL}[dependencies]${EOL}time = "0.1.12"${EOL}`,
+  './pyproject.toml': `[project]${EOL}name = "foo"${EOL}version = "${CURRENT_VERSION}"${EOL}# these are authors${EOL}authors = [{ name = "Alice", email = "a@example.com" }]${EOL}`
 });
 
 describe('toml file', { concurrency: true }, () => {
@@ -83,6 +84,20 @@ describe('toml file', { concurrency: true }, () => {
     assert.equal(
       readFile('./cargo.toml'),
       `[workspace]${EOL}${EOL}[package]${EOL}name = "hello_world"${EOL}version = "${NEW_VERSION}"${EOL}authors = [ "Alice <a@example.com>", "Bob <b@example.com>" ]${EOL}${EOL}[dependencies]${EOL}time = "0.1.12"${EOL}`
+    );
+  });
+
+  it('should read/write minimal changes', async () => {
+    const options = {
+      [NAMESPACE]: {
+        out: { file: './pyproject.toml', path: 'project.version' }
+      }
+    };
+    const plugin = factory(Bumper, { NAMESPACE, options });
+    await runTasks(plugin);
+    assert.equal(
+      readFile('./pyproject.toml'),
+      `[project]${EOL}name = "foo"${EOL}version = "${NEW_VERSION}"${EOL}# these are authors${EOL}authors = [{ name = "Alice", email = "a@example.com" }]${EOL}`
     );
   });
 });


### PR DESCRIPTION
This is an attempt to fix #38

I guess we can't rely on any parsing/serialization tool because toml is not so strict. Instead my solution tries to replace version with a narrow regexp.

I've also added test case that fails with currently released version of bumper.

Would be happy to receive feedback on this.