### PR TITLE
fix: example using wrong arument name

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ specified prefix to the bumped version:
     "out": {
       "file": "package.json",
       "path": "version",
-      "prefix": "^"
+      "versionPrefix": "^"
     }
   }
 }


### PR DESCRIPTION
fix wrong argument name in readme example