### PR TITLE
chore (deps): bump js-yaml to ^4.1.1 to avoid CVE-2025-64718

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "detect-indent": "7.0.1",
     "fast-glob": "^3.3.3",
     "ini": "^5.0.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.1.1",
     "lodash-es": "^4.17.21",
     "semver": "^7.7.1"
   },


### PR DESCRIPTION
see https://nvd.nist.gov/vuln/detail/CVE-2025-64718