### PR TITLE
test: update README and tests to use 'versionPrefix' instead of 'prefix'

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ specified prefix to the bumped version:
     "out": {
       "file": "package.json",
       "path": "version",
-      "prefix": "^"
+      "versionPrefix": "^"
     }
   }
 }

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -44,7 +44,7 @@ describe('release-it bumper', { concurrency: true }, () => {
     );
   });
 
-  it('should read one and write multiple files and respect prefix', async () => {
+  it('should read one and write multiple files and preserve existing version string prefix', async () => {
     const options = {
       [NAMESPACE]: {
         in: { file: 'VERSION', type: 'text/plain' },

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -67,7 +67,7 @@ describe('json file', { concurrency: true }, () => {
     );
   });
 
-  it('should update version with prefix', async () => {
+  it('should update version with versionPrefix', async () => {
     const options = {
       [NAMESPACE]: {
         out: {


### PR DESCRIPTION
Closes #49

## Summary
Updates documentation/tests to use `versionPrefix` instead of `prefix`.

## Changes
- `README.md`: update config example key from `prefix` → `versionPrefix`.
- `test/json.test.js`: update test title to reference `versionPrefix`.
- `test/general.test.js`: clarify test title wording (preserve existing version-string prefix).

## How to test
- `npm test`

No runtime behavior changes expected (docs/tests only).